### PR TITLE
Adding a new 'add-local-repo' role

### DIFF
--- a/add-local-repo/tasks/main.yml
+++ b/add-local-repo/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+- name: "Disable existing base, updates, and extras repositories"
+  become: true
+  ini_file:
+    dest: "/etc/yum.repos.d/CentOS-Base.repo"
+    section: "{{item}}"
+    option: enabled
+    value: 0
+  with_items:
+    - base
+    - updates
+    - extras
+- name: "Add local yum repository file"
+  become: true
+  template:
+    src: local-repo-template.j2
+    dest: "/etc/yum.repos.d/local.repo"
+    mode: 0644
+- name: Download keys for InfluxData and Confluent repositories
+  become: true
+  get_url:
+    url: "http://{{yum_repo_addr}}/repo/extern/gpg-keys/{{item}}"
+    dest: "/etc/pki/rpm-gpg/{{item}}"
+  with_items:
+    - confluent.key
+    - influxdb.key
+- name: Add keys to list of trusted keys for RPM installs
+  become: true
+  command: "rpm --import /etc/pki/rpm-gpg/{{item}}"
+  args:
+    warn: no
+  with_items:
+    - confluent.key
+    - influxdb.key
+- name: "remove all repository entries from the current yum cache"
+  become: true
+  command: yum clean all
+  args:
+    warn: no
+- name: "list all configured yum repositories"
+  become: true
+  command: yum repolist all
+  args:
+    warn: no

--- a/add-local-repo/templates/local-repo-template.j2
+++ b/add-local-repo/templates/local-repo-template.j2
@@ -1,0 +1,35 @@
+[os]
+name=master - Base
+baseurl=http://{{yum_repo_addr}}/repo/CentOS/$releasever/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[updates]
+name=master - Updates
+baseurl=http://{{yum_repo_addr}}/repo/CentOS/$releasever/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[extras]
+name=master - Extras
+baseurl=http://{{yum_repo_addr}}/repo/CentOS/$releasever/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[centosplus]
+name=master - CentosPlus
+baseurl=http://{{yum_repo_addr}}/repo/CentOS/$releasever/centosplus/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[influxdata]
+name=master - InfluxData
+baseurl=http://{{yum_repo_addr}}/repo/extern/influxdata/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/influxdb.key
+
+[confluent]
+name=master - Confluent
+baseurl=http://{{yum_repo_addr}}/repo/extern/confluent/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/confluent.key


### PR DESCRIPTION
Adds a new role that can be used to configure a node to use a local yum mirror (this role is intended by be used to a mirror on the local network, for example, so that updates can be made without reaching out across the internet to one of the 'standard' CentOS mirrors).

It is also assumed that the InfluxData and Confluent packages that we depend on can be retrieved from the same mirror; those dependencies are assumed to be at the following URIs:

* The Confluent public key:  `http://{{yum_repo_addr}}/repo/extern/gpg-keys/confluent.key`
* The InfluxData public key:  `http://{{yum_repo_addr}}/repo/extern/gpg-keys/influxdb.key`
* The Confluent packages:  `http://{{yum_repo_addr}}/repo/extern/confluent/x86_64/Packages/*.rpm`
* The InfluxData packages:  `http://{{yum_repo_addr}}/repo/extern/influxdata/x86_64/Packages/*.rpm`

The InfluxData packages (Telegraf and InfluxDB) can be downloaded directly from the InfluxData download site as standalone RPMs.  The Confluent OSS Packages can be downloaded using a command like:

```
$ yum install --downloadonly --downloaddir=<directory> confluent-platform-oss-2.11
```

That command will download the Confluent OSS platform and all of its dependencies and place them in the named directory.  The InfluxData and Confluent public keys are freely available from their respective websites.