### PR TITLE
Adds ability to skip setting of proxy for yum commands

### DIFF
--- a/add-local-repository/tasks/main.yml
+++ b/add-local-repository/tasks/main.yml
@@ -44,8 +44,9 @@
       dest: "/etc/yum.repos.d/{{repo_name}}.repo"
       remote_src: true
       mode: 0644
+    when: check_path.stat.exists
   become: true
-  when: check_path.stat.exists and (yum_repository is undefined or yum_repository is none or yum_repository | trim == '')
+  when: yum_repository is undefined or yum_repository is none or yum_repository | trim == ''
 # Finally, ensure that we clean up the yum cache and reload the (potentially new)
 # list of yum repositories
 - name: "remove all repository entries from the current yum cache"

--- a/setup-web-proxy/tasks/main.yml
+++ b/setup-web-proxy/tasks/main.yml
@@ -44,7 +44,7 @@
     regexp: "^proxy="
     line:  "proxy={{http_proxy}}"
     state: present
-  when: not (http_proxy is undefined or http_proxy is none or http_proxy | trim == '')
+  when: not (http_proxy is undefined or http_proxy is none or http_proxy | trim == '') and (skip_yum_proxy is undefined or not (skip_yum_proxy))
 - name: remove http_proxy from yum.conf if defined
   become: true
   lineinfile:
@@ -59,7 +59,7 @@
     regexp: "^proxy_username="
     line:  "proxy_username={{proxy_username}}"
     state: present
-  when: not (proxy_username is undefined or proxy_username is none or proxy_username | trim == '')
+  when: not (proxy_username is undefined or proxy_username is none or proxy_username | trim == '')  and (skip_yum_proxy is undefined or not (skip_yum_proxy))
 - name: remove proxy_username from yum.conf if defined
   become: true
   lineinfile:
@@ -74,7 +74,7 @@
     regexp: "^proxy_password="
     line:  "proxy_password={{proxy_password}}"
     state: present
-  when: not (proxy_password is undefined or proxy_password is none or proxy_password | trim == '')
+  when: not (proxy_password is undefined or proxy_password is none or proxy_password | trim == '')  and (skip_yum_proxy is undefined or not (skip_yum_proxy))
 - name: remove proxy_password from yum.conf if defined
   become: true
   lineinfile:


### PR DESCRIPTION
This pull request adds the ability to skip setting the proxy in the `/etc/yum.conf` file in cases where a proxy must be setup for commands that are going to be executed but a local yum mirror is being used.  By simply setting the `skip_yum_proxy` flag to `true` the proxy information used to setup the environment variables needed to download packages through the firewall can be setup but the local yum mirror can still be used.

In addition, this pull request fixes a bug in how the `add-local-repository` role determined if the local repository file should be overwritten with the backup copy.  This was accomplished by using a block and a when clause to separate out the test for whether the `yum_repository` was specified from the check for whether the backup copy exists.