### PR TITLE
Changes to support host groups in static inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,30 @@ Common roles that are intended to be shared (reused) across multiple Ansible pla
 
 # Use
 To use these common roles in another GitHub repository, simply add this repository as a (git) submodule of that repository.  This can be accomplished by running a command that looks something like the following:
+
 ```bash
 $ git submodule add https://github.com/Datanexus/common-roles common-roles
 ```
+
 This will create a `common-roles` subdirectory, then clone this repository into that `common-roles` subdirecory and checkout the latest commit from this repository, and create a `.gitmodules` file that looks something like the following:
+
 ```yaml
 [submodule "common-roles"]
 	path = common-roles
 	url = https://github.com/Datanexus/common-roles
 ```
+
 Once the `common-roles` repository has been added as a submodule, the next step is to add the `common-roles` directory to the `roles_path` used by Ansible.  This can be accomplished by creating an `ansible.cfg` file in the same directory as the playbook that will be run that looks something like this:
+
 ```yaml
 [defaults]
-roles_path = common-roles
+roles_path = ../:common-roles
 ```
+
 With the submodule added and the `roles_path` modified to ensure that the roles in this repository are included in the `roles_path` used by the `ansible-playbook` command, the roles in this repository can then be used in any playbooks that might be defined in the repository that this `common-roles` repository is being added to as a submodule.
 
 To commit the changes made by the process of adding this repository as a submodule, you would then run a series of commands that look something like this:
+
 ```bash
 $ git add common-roles ansible.cfg
     ...
@@ -31,12 +38,14 @@ $ git push
 
 # Cloning the resulting repository
 To clone the resulting repository, simply add a `--recursive` flag to the `git clone` command that you would normally use.  For example, the following command will clone the `dn-solr` repository from the `Datanexus` organization at GitHub.com (which includes this repository as a submodule):
+
 ```bash
 $ git clone --recursive https://github.com/Datanexus/dn-solr
 ```
 
 # Pulling changes into the resulting repository
 If this repository is modified and the developer of a repository that includes this one as a submodule wants to pull the latest changes into their repository, they can do that quite easily by using a sequence of commands that look something like this:
+
 ```bash
 $ cd common-roles
 $ git checkout master
@@ -50,4 +59,5 @@ $ git commit -m "updating common-roles submodule version"
 $ git push
     ...
 ```
+
 This sequence of commands will pull down the latest changes from the `https://github.com/Datanexus/common-roles` repository, update the version of the `common-roles` submodule that is used by the  repository that depends on it, and commit that new version to that repository.

--- a/build-app-host-groups/files/build_static_host_groups.yml
+++ b/build-app-host-groups/files/build_static_host_groups.yml
@@ -21,12 +21,18 @@
 # the `inventory_file` passed in as part of the 'host_group_item' map
 # (by parsing it as a static inventory file)
 - block:
-  - local_action: "shell {{playbook_dir}}/common-utils/inventory/static/hostsfile.py --filename {{host_group_item.inventory_file}}"
-    register: zookeeper_inventory_out
+  - local_action: "shell {{playbook_dir}}/common-utils/inventory/static/hostsfile.py --filename {{host_group_item.inventory_file}} --list"
+    register: inventory_out
   - set_fact:
-      hg_item_inventory: "{{(zookeeper_inventory_out.stdout | from_json)._meta.hostvars}}"
+      hg_item_inventory_out_json: "{{inventory_out.stdout | from_json}}"
+  - set_fact:
+      hg_item_inventory: "{{hg_item_inventory_out_json._meta.hostvars}}"
+  - set_fact:
+      hg_item_nodes: "{{hg_item_inventory_out_json[hg_item_name].hosts}}"
+    when: (hg_item_inventory_out_json[hg_item_name] | default({})) != {}
   - set_fact:
       hg_item_nodes: "{{ hg_item_inventory | json_query('keys(@)') }}"
+    when: (hg_item_inventory_out_json[hg_item_name] | default({})) == {}
   run_once: true
   when: inventory_included
 # set the node list fact based on the input 'node_list_name'

--- a/build-app-host-groups/tasks/main.yml
+++ b/build-app-host-groups/tasks/main.yml
@@ -15,7 +15,7 @@
       tenant_nodes: "{{di_output_json | json_query('tag_Tenant_' + tenant)}}"
       project_nodes: "{{di_output_json | json_query('tag_Project_' + project)}}"
       domain_nodes: "{{di_output_json | json_query('tag_Domain_' + domain)}}"
-  when: cloud == "aws"
+  when: inventory_type == 'dynamic' and cloud == "aws"
 
 # If we're running this command for to build a cluster in OpenStack, then use the
 # `openstack` command to gather the dynamic inventory information that we need to
@@ -32,7 +32,7 @@
       tenant_nodes: "{{(di_output_json | json_query('[\"meta-Tenant_' + tenant + '\"]')).0}}"
       project_nodes: "{{(di_output_json | json_query('[\"meta-Project_' + project + '\"]')).0}}"
       domain_nodes: "{{(di_output_json | json_query('[\"meta-Domain_' + domain + '\"]')).0}}"
-  when: cloud == "osp"
+  when: inventory_type == 'dynamic' and cloud == "osp"
 
 # if we're not working with a static inventory (i.e. if wer'e working with inventory from an AWS
 # or OpenStack cloud), then loop through the host_group_types list, building each host group
@@ -41,7 +41,7 @@
   with_items: "{{host_group_list}}"
   loop_control:
     loop_var: host_group_item
-  when: cloud == "aws" or cloud == "osp"
+  when: inventory_type == 'dynamic'
 
 # Otherwise, if we are working with a static inventory, then loop through the host_group_types list,
 # building each host group (in turn)
@@ -49,4 +49,4 @@
   with_items: "{{host_group_list}}"
   loop_control:
     loop_var: host_group_item
-  when: cloud == "vagrant"
+  when: inventory_type == 'static'


### PR DESCRIPTION
The changes in this pull request add support for host groups to the parsing of static inventory files done by the `build-app-host-groups` role; specifically:

* If a host group that matches the `host_group_item.name` value passed into the `build-app-host-groups` role (a `zookeeper` host group, for example) exists in the static inventory file that is also passed into that role, then that host group will be used to construct the list of hosts that should be in the resulting host group that the role is constructing from that static inventory file.
* If, on the other hand, a corresponding host group is not found in that static inventory file, then it will be assumed that all of the hosts in that file should be placed into the host group that the role is constructing; this assumption is necessary to preserve the previous behavior of this role (which assumed that all hosts in the input static inventory file should be placed in the corresponding host group).

In addition, this PR changes the behavior of this role to key off of a new `inventory_type` variable that is passed into the role rather than simply keying off of the `cloud` variable. Previously, if the `cloud` variable was set to `vagrant` the inventory was assumed to be managed statically, but if it was set to `osp` or `aws` the inventory was assumed to be set dynamically. Now, the role will assume that the inventory is being managed statically if the `inventory_type` is set to `static` and that it is being managed dynamically if the `inventory_type` is set to dynamic. Only if the `inventory_type` is dynamic will the `cloud` variable be taken into account (since this role will need to change how the inventory is retrieved and parsed based on whether the cloud is an `aws` or `osp` cloud.

Finally, we updated the documentation to ensure that the Markdown is rendered correctly and that the `roles_path` that should be set by the user in their `ansible.cfg` file is updated to reflect current usage.