### PR TITLE
Moves code to get data and api addresses to initialize-play common role

### DIFF
--- a/initialize-play/tasks/main.yml
+++ b/initialize-play/tasks/main.yml
@@ -25,3 +25,19 @@
   vars:
     iface_descriptions: "{{iface_description_array}}"
   when: not (iface_description_array is undefined or iface_description_array == [])
+# Now that we have all of the facts we need, we can run the roles that are used
+# to deploy and configure the application we're deploying on our input nodes;
+# first get values for the addresses of the `data_iface` and `api_iface`
+# (if defined)
+- include_role:
+    name: get-iface-addr
+  vars:
+    iface_name: "{{data_iface}}"
+    as_fact: "data_addr"
+  when: (data_iface | default('')) != ''
+- include_role:
+    name: get-iface-addr
+  vars:
+    iface_name: "{{api_iface}}"
+    as_fact: "api_addr"
+  when: (api_iface | default('')) != ''


### PR DESCRIPTION
The changes in this PR move the code that retrieves the data and api addresses from the named data and api interfaces from the `provision-nodes` common flow to the `initialize-play` common role; to accomplish this, both the changes in this PR and those in [PR #1](https://github.com/Datanexus/common-flows/pull/1) in the common-flows repository should be merged together (and both submodules should be updated to the latest update together in any playbooks that use these two submodules).